### PR TITLE
Added explicit import of the floor function from math package

### DIFF
--- a/ganglia-logtailer/src/ganglia-logtailer
+++ b/ganglia-logtailer/src/ganglia-logtailer
@@ -32,6 +32,7 @@ import fcntl
 sys.path.append("/usr/share/ganglia-logtailer")
 from tailnostate import LogTail
 from ganglia_logtailer_helper import LogtailerParsingException, LogtailerStateException, LockingError
+from math import floor
 
 ## globals
 gmetric = '/usr/bin/gmetric'


### PR DESCRIPTION
On CentOS 5.4 with Python 2.4.3 I got an error about a non defined floor function.
Now added it explicitly (shouldn't hurt anyone else).
