### PR TITLE
Spoofing support in gmetric.py

### DIFF
--- a/gmetric-python/gmetric.py
+++ b/gmetric-python/gmetric.py
@@ -87,7 +87,7 @@ class Gmetric:
         if len(NAME) == 0:
             raise ValueError("Name must be non-empty")
 
-        ( meta_msg, data_msg )  = gmetric_write(NAME, VAL, TYPE, UNITS, SLOPE, TMAX, DMAX, SPOOF, GROUP)
+        ( meta_msg, data_msg )  = gmetric_write(NAME, VAL, TYPE, UNITS, SLOPE, TMAX, DMAX, GROUP, SPOOF)
         # print msg
 
         self.socket.sendto(meta_msg, self.hostport)


### PR DESCRIPTION
I think spoofing support is something useable by most who would be interested in a pure python gmetric reporter. In my tests, this works just fine, now I have the ability to report ILOM temperatures as belonging to a host without making a subprocess call off to the gmetric binary.
