### PR TITLE
Added Ganglia cluster name as the path root

### DIFF
--- a/graphite_integration/ganglia_graphite.rb
+++ b/graphite_integration/ganglia_graphite.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/ruby -d
 
 #################################################################################
 # Parse Ganglia XML stream and send metrics to Graphite
@@ -14,6 +14,7 @@ ganglia_hostname = 'localhost'
 ganglia_port = 8649
 graphite_host = "localhost"
 graphite_port = "2003"
+Debug = false
 
 begin
   # Open up a socket to gmond
@@ -24,13 +25,22 @@ begin
   now = Time.now.to_i
   # Parse the XML we got from gmond
   doc = REXML::Document.new file
+
+  # Set the cluster name as path root
+  cluster_prefix=nil
+  doc.elements.each("GANGLIA_XML/CLUSTER") { |element| 
+   # Convert all non Word characters to _
+   cluster_prefix=element.attributes["NAME"].gsub(/\W/, "_")
+  }
+
   doc.elements.each("GANGLIA_XML/CLUSTER/HOST") { |element|
     # Set metric prefix to the host name. Graphite uses dots to separate subtrees
     # therefore we have to change dots in hostnames to _
     metric_prefix=element.attributes["NAME"].gsub(".", "_")
     element.elements.each("METRIC") { |metric|
       if metric.attributes["TYPE"] != "string"                     
-        graphite.puts "#{metric_prefix}.#{metric.attributes["NAME"]} #{metric.attributes["VAL"]} #{now}\n"
+        graphite.puts "#{cluster_prefix}.#{metric_prefix}.#{metric.attributes["NAME"]} #{metric.attributes["VAL"]} #{now}\n"
+        puts "#{cluster_prefix}.#{metric_prefix}.#{metric.attributes["NAME"]} #{metric.attributes["VAL"]} #{now}\n" if Debug
       end
     }
   }


### PR DESCRIPTION
I believe it makes sense to store the hosts under the cluster name instead of the top level.  This allows for easier navigation and node comparison in graphite.  My change has this as a requirement but could easily be an option if others wish.
