### PR TITLE
2 small changes

### DIFF
--- a/ganglia-alert/ganglia-alert
+++ b/ganglia-alert/ganglia-alert
@@ -10,7 +10,7 @@ use POSIX ":sys_wait_h";
 
 use Pod::Usage;
 
-our $VERSION = '0.9.' . [qw$Revision: 22 $]->[1];
+our $VERSION = '0.9.' . [qw$Revision: 24 $]->[1];
 
 # in-memory stats
 my %history;				# history for average/stdev
@@ -188,6 +188,8 @@ sub safe_from_hdat {
                         ${$safe->varglob($metric . "_stdev")} = 0;
                 }
         }
+	${$safe->varglob("reported")}=$hdat->{reported};
+	${$safe->varglob("tn")}=$hdat->{tn};
 	return $safe;
 }
 
@@ -502,20 +504,24 @@ sub msgq {
 			$alertm = 0;
 		} else {
 			my $ok = 0;
-			my $from = $conf{email_from} ? $conf{email_from} : ("$uid\@" . ($ENV{HOST} ? $ENV{HOST} : 'localhost'));
-			if ($conf{sendmail_path}) {
-				$ok = open(SM, "|$conf{sendmail_path} -f $from -t $addr");
-				$ok = $ok && print(SM "From: $from\nTo: $addr\nSubject: $subject\n\n$rpt");
-				$ok = $ok && close(SM);
+			if ($conf{email_to}) {
+				my $from = $conf{email_from} ? $conf{email_from} : ("$uid\@" . ($ENV{HOST} ? $ENV{HOST} : 'localhost'));
+				if ($conf{sendmail_path}) {
+					$ok = open(SM, "|$conf{sendmail_path} -f $from -t $addr");
+					$ok = $ok && print(SM "From: $from\nTo: $addr\nSubject: $subject\n\n$rpt");
+					$ok = $ok && close(SM);
+				} else {
+					my $msg = MIME::Lite->new(
+						From     => $from,
+						To       => $addr,
+						Subject  => $subject,
+						Type     => 'text/plain',
+						Data     => $rpt
+					);
+					$ok = $msg->send;
+				}
 			} else {
-				my $msg = MIME::Lite->new(
-					From     => $from,
-					To       => $addr,
-					Subject  => $subject,
-					Type     => 'text/plain',
-					Data     => $rpt
-				);
-				$ok = $msg->send;
+				$ok = 1;
 			}
 			if ($ok) {
 				$alertm = 0;	


### PR DESCRIPTION
1 - when you issue a "reconfig" or kill -hup, any values you removed from tyour confiug aren't undef'ed they are deleted from memory

2 - MIME-Lite support works.... also if you don't have an email_to param, that's OK, it will log only (good for debugging)
