### PR TITLE
use nokogiri

### DIFF
--- a/graphite_integration/ganglia_graphite_2.rb
+++ b/graphite_integration/ganglia_graphite_2.rb
@@ -3,7 +3,7 @@
 #################################################################################
 # Parse Ganglia XML stream and send metrics to Graphite
 # License: Same as Ganglia
-# Author: Vladimir Vuksan
+# Author: Gilles Devaux
 # Modified from script written by: Vladimir Vuksan
 # at https://github.com/ganglia/ganglia_contrib/blob/master/graphite_integration/ganglia_graphite.rb
 #


### PR DESCRIPTION
Hi,

Here's a version using the Nokogiri parser.
Using rexml took 20 seconds to parse 2.5M XML file (160 nodes), nokogiri takes about 1s.
There is also a trick to use group name to get a nicer tree under Graphite, feel free to backport it (or tell me if you like it if you'd like me to do it)

Thanks

--Gilles
