### PR TITLE
Fix to remove spaces in GROUP if the element exists

### DIFF
--- a/graphite_integration/ganglia_graphite_2.rb
+++ b/graphite_integration/ganglia_graphite_2.rb
@@ -60,7 +60,7 @@ begin
 
           group = metric.at("EXTRA_DATA/EXTRA_ELEMENT[@NAME=GROUP]")
           if group
-            group_name = group['VAL']
+            group_name = group['VAL'].gsub(/\W/, "_")
           else
             #Trick for gmetric < 3.2 (do not have --group option)
             #Name your metric group_metric_name


### PR DESCRIPTION
Ran into some GROUP names yesterday that had spaces, so I tacked on a gsub(/\W/, "_") to the setting of group_name to make sure Graphite can read it when it comes in. (it was throwing "invalid line" errors on the Graphite relay side)
