### PR TITLE
ganglia-logtailer quoting arguments in shelling out to prevent special characters from doing terrible things

### DIFF
--- a/ganglia-logtailer/debian/changelog
+++ b/ganglia-logtailer/debian/changelog
@@ -2,6 +2,8 @@ ganglia-logtailer (1.9) stable; urgency=low
 
   * switching from os.system() with string interpolation to subprocess.call
     to protect the call out from bad metric names (eg special characters)
+  * sanitizing the metric name before submission by stripping out all
+    non-alphanumerics except hyphen, period, and underscore
 
  -- Ben Hartshorne <ben@hartshorne.net>  Mon,  7 Apr 2014 17:48:00 -0700
 

--- a/ganglia-logtailer/src/ganglia-logtailer
+++ b/ganglia-logtailer/src/ganglia-logtailer
@@ -95,10 +95,9 @@ def submit_stats( parser, missing_as_zero_state_file, missing_as_zero, metric_pr
                 logger.debug(e)
                 pass
         for m in metrics:
-
+            m.sanitize_metric_name()
             if ( metric_prefix != "" ):
                 m.name = metric_prefix + "_" + m.name
-
             logger.debug( "Submitting gmetric: %s %s --name %s --value %s --type %s --units %s --tmax %s --dmax %s" %
                  (gmetric, gmetric_options, m.name, m.value, m.type, m.units, m.tmax, m.dmax) )
             gmetric_call = [

--- a/ganglia-logtailer/src/ganglia_logtailer_helper.py
+++ b/ganglia-logtailer/src/ganglia_logtailer_helper.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 """class for ganglia metric objects to be passed around"""
+import re
 
 class GangliaMetricObject(object):
     def __init__(self, name, value, units='', type='float', tmax=60, dmax=0):
@@ -22,6 +23,9 @@ class GangliaMetricObject(object):
         self.type = hashed_object["type"]
         self.tmax = hashed_object["tmax"]
         self.dmax = hashed_object["dmax"]
+    def sanitize_metric_name(self):
+        """sanitize metric names by translating all non alphanumerics to underscore"""
+        self.name = re.sub("[^A-Za-z0-9._-]", "_", self.name)
     def __eq__(self, other):
         """A ganglia metric object is equivalent if the name is the same."""
         return self.name == other.name


### PR DESCRIPTION
unquoted & in something like the metric name will be interpreted by the shell and cause terrible side effects.
