### PR TITLE
Revised docker contrib instructions

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -26,15 +26,15 @@ and just mount it inside the gmetad container. This is so we can persist it easi
 
 For example we'll need to do something like this
 
-<pre>
-mkdir -p /var/lib/ganglia/rrds
-chown -R 999:999 /var/lib/ganglia
-cat <<ENDOF > /etc/ganglia/gmetad.conf
-data_source "cluster1" gmond1:8649
-setuid_username "ganglia"
+```
+sudo mkdir -p /var/lib/ganglia/rrds /etc/ganglia
+sudo chown -R 999:999 /var/lib/ganglia
+sudo sh -c "cat > /etc/ganglia/gmetad.conf <<EOL
+data_source \"cluster1\" gmond1:8649
+setuid_username \"ganglia\"
 case_sensitive_hostnames 0
-ENDOF
-</pre>
+EOL"
+```
 
 # Start up containers
 
@@ -51,17 +51,15 @@ sudo docker run -d --name gmetad1 \
 	-v /etc/ganglia/gmetad.conf:/etc/ganglia/gmetad.conf \
 	-v /var/lib/ganglia:/var/lib/ganglia \
 	--link gmond1:gmond1 \
-	-p 0.0.0.0:80:80 ganglia-aggregator
+	-p 0.0.0.0:80:80 gmetad-gangliaweb
 </pre>
 
 # Explanation
 
 What will happen here is following
 
-  - Gmond aggregator will be started on port 8649. It will expose UDP port 8649 on the host hosting the containers. That host is going to be
-    called gmond1
-  - When we launch gmetad-gangliaweb container it will mount /var/lib/ganglia and /etc/ganglia/gmetad.conf from the
-  docker host inside the container
+  - Gmond aggregator will be started on port 8649. It will expose UDP port 8649 on the host hosting the containers. That host is going to be called gmond1
+  - When we launch gmetad-gangliaweb container it will mount /var/lib/ganglia and /etc/ganglia/gmetad.conf from the docker host inside the container
   - In addition gmond1 container will be linked with the gmetad1 container so gmetad1 can access it
   - Using --link will assure that /etc/hosts file in gmetad1 container is updated with the internal IP for gmond1
-
+  - Ganglia Web will be availble on http://localhost/ganglia


### PR DESCRIPTION
Fixed the configuration files and directories instructions so that it should just work.

The previous instructions were trying to start a `ganglia-aggregator` Docker container rather than the `gmetad-gangliaweb` container.

Added a link from the Docker host to the ganglia webpage for other noobs like me.